### PR TITLE
doc fix: uuid4 instead uuid1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Bug fixes:
 - Fix package dependencies.
   [gforcada]
 
+- Fix documentation and uuid generator class name to reflect the fact that we use the ``uuid4`` implementation instead of ``uuid1``.
+  [thet]
+
+
 1.0.4 (2016-06-02)
 ------------------
 
@@ -27,6 +31,7 @@ Bug fixes:
 
 - Fixed issues preventing tests passing on Python 3
   [datakurre]
+
 
 1.0.3 (2012-05-31)
 ------------------
@@ -39,11 +44,13 @@ Bug fixes:
   copy event, where original and destination should have distinct UUID.
   [seanupton]
 
+
 1.0.2 - 2011-10-18
 ------------------
 
 - Generate UUID without dashes.
   [elro]
+
 
 1.0.1 - 2011-05-20
 ------------------
@@ -51,6 +58,7 @@ Bug fixes:
 - Relicense under modified BSD license.
   See http://plone.org/foundation/materials/foundation-resolutions/plone-framework-components-relicensing-policy
   [davisagli]
+
 
 1.0 - 2011-05-13
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ This is a minimal package that can be used to obtain a universally unique
 identifier (UUID) for an object.
 
 The default implementation uses the Python standard library ``uuid`` module
-to generate an RFC 4122-compliant UUID, using the ``uuid1()`` function. It
+to generate an RFC 4122-compliant UUID, using the ``uuid4()`` function. It
 will assign a UUID upon object creation (by subscribing to
 ``IObjectCreatedEvent`` from ``zope.lifecycleevent``) and store it in an
 attribute on the object.
@@ -70,8 +70,9 @@ There are two primary customisation points for this package:
 
 * You can change the default UUID generating algorithm by overriding the
   unnamed utility providing the ``IUUIDGenerator`` interface. The default
-  implementation simply calls ``uuid.uuid1()`` and casts the result to a
+  implementation simply calls ``uuid.uuid4()`` and casts the result to a
   ``str``.
+
 * You can change the UUID storage by providing a custom ``IUUID`` adapter
   implementation. If you do this, you must also provide a mechanism for
   assigning UUIDs upon object creation, usually via an event handler. To

--- a/plone/__init__.py
+++ b/plone/__init__.py
@@ -1,6 +1,2 @@
-# See http://peak.telecommunity.com/DevCenter/setuptools#namespace-packages
-try:
-    __import__('pkg_resources').declare_namespace(__name__)
-except ImportError:
-    from pkgutil import extend_path
-    __path__ = extend_path(__path__, __name__)
+# -*- coding: utf-8 -*-
+__import__('pkg_resources').declare_namespace(__name__)

--- a/plone/uuid/__init__.py
+++ b/plone/uuid/__init__.py
@@ -1,1 +1,1 @@
-# -*- extra stuff goes here -*-
+# -*- coding: utf-8 -*-

--- a/plone/uuid/adapter.py
+++ b/plone/uuid/adapter.py
@@ -1,7 +1,7 @@
-from zope import interface
-from zope import component
-
+# -*- coding: utf-8 -*-
 from plone.uuid import interfaces
+from zope import component
+from zope import interface
 
 
 @interface.implementer(interfaces.IUUID)

--- a/plone/uuid/browser.py
+++ b/plone/uuid/browser.py
@@ -1,7 +1,10 @@
-from zope.publisher.browser import BrowserView
+# -*- coding: utf-8 -*-
 from plone.uuid.interfaces import IUUID
+from zope.publisher.browser import BrowserView
 
 import sys
+
+
 if sys.version_info >= (3,):
     text_type = str
 else:

--- a/plone/uuid/configure.zcml
+++ b/plone/uuid/configure.zcml
@@ -14,7 +14,7 @@
 
     <adapter factory=".adapter.attributeUUID" />
     <adapter factory=".adapter.MutableAttributeUUID" />
-    <utility factory=".generator.UUID1Generator" />
+    <utility factory=".generator.UUID4Generator" />
     <subscriber handler=".handlers.addAttributeUUID" />
 
     <browser:view

--- a/plone/uuid/configure.zcml
+++ b/plone/uuid/configure.zcml
@@ -5,23 +5,23 @@
     xmlns:i18n="http://namespaces.zope.org/i18n"
     i18n_domain="plone.uuid">
 
-    <include package="zope.component" file="meta.zcml" />
-    <include package="zope.component" />
+  <include package="zope.component" file="meta.zcml" />
+  <include package="zope.component" />
 
-    <!-- Make sure we test the Zope 2 version of view registrations in Zope 2 -->
-    <include zcml:condition="installed Products.Five" package="Products.Five.browser" file="meta.zcml" />
-    <include zcml:condition="not-installed Products.Five" package="zope.browserpage" file="meta.zcml" />
+  <!-- Make sure we test the Zope 2 version of view registrations in Zope 2 -->
+  <include zcml:condition="installed Products.Five" package="Products.Five.browser" file="meta.zcml" />
+  <include zcml:condition="not-installed Products.Five" package="zope.browserpage" file="meta.zcml" />
 
-    <adapter factory=".adapter.attributeUUID" />
-    <adapter factory=".adapter.MutableAttributeUUID" />
-    <utility factory=".generator.UUID4Generator" />
-    <subscriber handler=".handlers.addAttributeUUID" />
+  <adapter factory=".adapter.attributeUUID" />
+  <adapter factory=".adapter.MutableAttributeUUID" />
+  <utility factory=".generator.UUID4Generator" />
+  <subscriber handler=".handlers.addAttributeUUID" />
 
-    <browser:view
-        name="uuid"
-        class=".browser.UUIDView"
-        for=".interfaces.IUUIDAware"
-        permission="zope.Public"
-        />
+  <browser:view
+      name="uuid"
+      class=".browser.UUIDView"
+      for=".interfaces.IUUIDAware"
+      permission="zope.Public"
+      />
 
 </configure>

--- a/plone/uuid/generator.py
+++ b/plone/uuid/generator.py
@@ -1,11 +1,12 @@
-import uuid
-
-from zope.interface import implementer
 from plone.uuid.interfaces import IUUIDGenerator
+from zope.deprecation import deprecate
+from zope.interface import implementer
+
+import uuid
 
 
 @implementer(IUUIDGenerator)
-class UUID1Generator(object):
+class UUID4Generator(object):
     """Default UUID implementation.
 
     Uses uuid.uuid4()
@@ -13,3 +14,12 @@ class UUID1Generator(object):
 
     def __call__(self):
         return uuid.uuid4().hex
+
+
+@deprecate(
+    'UUID1Generator was renamed to UUID4Generator, as we use uuid4 instead of '
+    'uuid1. Please use UUID4Generator instead.'
+)
+class UUID1Generator(UUID4Generator):
+    """BBB. Remove with next major version.
+    """

--- a/plone/uuid/generator.py
+++ b/plone/uuid/generator.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from plone.uuid.interfaces import IUUIDGenerator
 from zope.deprecation import deprecate
 from zope.interface import implementer

--- a/plone/uuid/handlers.py
+++ b/plone/uuid/handlers.py
@@ -1,13 +1,12 @@
+# -*- coding: utf-8 -*-
+from plone.uuid.interfaces import ATTRIBUTE_NAME
+from plone.uuid.interfaces import IAttributeUUID
+from plone.uuid.interfaces import IUUIDGenerator
 from zope.component import adapter
 from zope.component import queryUtility
-
-from zope.lifecycleevent.interfaces import IObjectCreatedEvent
 from zope.lifecycleevent.interfaces import IObjectCopiedEvent
+from zope.lifecycleevent.interfaces import IObjectCreatedEvent
 
-from plone.uuid.interfaces import IUUIDGenerator
-from plone.uuid.interfaces import IAttributeUUID
-
-from plone.uuid.interfaces import ATTRIBUTE_NAME
 
 try:
     from Acquisition import aq_base

--- a/plone/uuid/interfaces.py
+++ b/plone/uuid/interfaces.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 from zope.interface import Interface
+
 
 ATTRIBUTE_NAME = '_plone.uuid'
 

--- a/plone/uuid/tests.py
+++ b/plone/uuid/tests.py
@@ -1,6 +1,8 @@
+# -*- coding: utf-8 -*-
+import sys
 import unittest
 
-import sys
+
 if sys.version_info >= (3,):
     text_type = str
 else:

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,7 @@
-from setuptools import setup, find_packages
+# -*- coding: utf-8 -*-
+from setuptools import find_packages
+from setuptools import setup
+
 
 version = '1.0.5.dev0'
 


### PR DESCRIPTION
Fix documentation and uuid generator class name to reflect the fact that we use the uuid4 implementation instead of uuid1.

We use uuid4 almost from the beginning of all plone.uuid times: https://github.com/plone/plone.uuid/commit/c050551d5a5e6d1cb7de7d067d6c5e7fd3b5d3ad - that was the 3rd commit.
  